### PR TITLE
README fixes: typo fix and public domain notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,12 @@
 # PartnershipPlaybook
 This guide will help you, as an agency, understand what it’s like to work with 18F. The playbook is broken down into eight principles. You'll learn what to expect and get a sense of the challenges you may face when working with a modern digital service team, which will likely be a significantly different experience than working with a contractor. 
 
-This playbook is a compliment to the [U.S. Digital Services Playbook](https://playbook.cio.gov).
+This playbook is a complement to the [U.S. Digital Services Playbook](https://playbook.cio.gov).
+
+### Public domain
+
+This project is in the worldwide [public domain](LICENSE.md). As stated in [CONTRIBUTING](CONTRIBUTING.md):
+
+> This project is in the public domain within the United States, and copyright and related rights in the work worldwide are waived through the [CC0 1.0 Universal public domain dedication](https://creativecommons.org/publicdomain/zero/1.0/).
+>
+> All contributions to this project will be released under the CC0 dedication. By submitting a pull request, you are agreeing to comply with this waiver of copyright interest.


### PR DESCRIPTION
Fixing "compliment" -> "complement", and adding a public domain note to the README as recommended by https://github.com/18F/open-source-policy/blob/master/practice.md#how-to-license-18f-repos
