### PR TITLE
Remove "back-end" specific mentions - expand to include front-end example

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -51,7 +51,7 @@ navigation:
   url: 7-transfer-projects-back/
   internal: true
 - text: 8. We deploy projects using best practice back-end methods and technology
-  url: 8-best-practice-back-end/
+  url: 8-best-practice/
   internal: true
 
 

--- a/index.md
+++ b/index.md
@@ -13,7 +13,7 @@ The principles we use in working together are:
 5. [We use user-centered research and design methods.]({{site.baseurl}}/5-user-centered-design/)
 6. [We may revisit the project at a high level if there is a major change in project goals.]({{site.baseurl}}/6-revisit-if-major-goals-change/)
 7. [We transfer projects back to your team for ongoing support.]({{site.baseurl}}/7-transfer-projects-back/)
-8. [We deploy projects using best practice methods and technology.]({{site.baseurl}}/8-best-practice-back-end/)
+8. [We deploy projects using best practice methods and technology.]({{site.baseurl}}/8-best-practice)
 
 We’ll explain what each principle will mean to you as our partner. We also provide a set of prompting questions in the “How do you know if you’re ready” sections, which you can use with stakeholders to assess potential conflict points that may need to be resolved before we partner.
 

--- a/index.md
+++ b/index.md
@@ -13,7 +13,7 @@ The principles we use in working together are:
 5. [We use user-centered research and design methods.]({{site.baseurl}}/5-user-centered-design/)
 6. [We may revisit the project at a high level if there is a major change in project goals.]({{site.baseurl}}/6-revisit-if-major-goals-change/)
 7. [We transfer projects back to your team for ongoing support.]({{site.baseurl}}/7-transfer-projects-back/)
-8. [We deploy projects using best practice back-end methods and technology.]({{site.baseurl}}/8-best-practice-back-end/)
+8. [We deploy projects using best practice methods and technology.]({{site.baseurl}}/8-best-practice-back-end/)
 
 We’ll explain what each principle will mean to you as our partner. We also provide a set of prompting questions in the “How do you know if you’re ready” sections, which you can use with stakeholders to assess potential conflict points that may need to be resolved before we partner.
 

--- a/pages/8-best-practice-back-end.md
+++ b/pages/8-best-practice-back-end.md
@@ -1,6 +1,6 @@
 ---
-permalink: /8-best-practice-back-end/
-title: 8. We deploy projects using best practice back-end methods and technology
+permalink: /8-best-practice/
+title: 8. We deploy projects using best practice methods and technology
 ---
 
 There are some specific technical ways we work that are important for your team to consider when deciding if working with 18F is right for you. 
@@ -10,3 +10,4 @@ There are some specific technical ways we work that are important for your team 
 - We practice continuous change and continuous deployment of software alongside appropriate testing procedures before deployment. One advantage of this setup is that "change control" systems are not needed for durable development and testing.
 - 18F does not fill a "systems integrator" role on its projects. Sometimes, our services may rely on dependencies where other teams provide support. We'll work with you to resolve all concerns in the parts of the project we own, but the project's needs may sometimes require the product owner to seek fixes from administrators of the other systems.
 - We typically develop with market-supported languages used widely in the modern web development community, such as Ruby, Python, or Node.js. We also develop some systems using Go. These languages all strongly support rapid development models, thanks to standard open source code-sharing systems, and each has a vibrant community around it that attracts talented developers. We generally do not develop solutions in .NET, Java, C, or C++.
+- We design for modern platforms and mobile best practices for responsive display


### PR DESCRIPTION
I'm not sure why it shows the full list as a diff in previous changes... I just think the word "back end" is misleading since we use a lot of best practices and methods for front-end solutions too (e.g. reactive web design for browsers).
