### PR TITLE
Removes syntax highlighter fixing the Federalist build

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -9,7 +9,6 @@ exclude:
 - go
 
 permalink: pretty
-highlighter: rouge
 
 sass:
   style: :compressed


### PR DESCRIPTION
This fixes the build which was failing because the latest versions of ruby and Jekyll don't like this syntax for syntax highlighting (or I think that's the problem, this same fix also worked on another site I was working with recently).

[Preview](https://federalist.18f.gov/preview/gboone/partnership-playbook/fix-build/)